### PR TITLE
Fix for PayloadTooLarge error when saving a large chat filesize

### DIFF
--- a/server.js
+++ b/server.js
@@ -41,8 +41,8 @@ var api_key_novel;
 
 var is_colab = false;
 
-const jsonParser = express.json();
-const urlencodedParser = express.urlencoded({extended: false});
+const jsonParser = express.json({limit: '100mb'});
+const urlencodedParser = express.urlencoded({extended: true, limit: '100mb'});
 
 
 


### PR DESCRIPTION
This commit fixes issue #23 by increasing the size limit to 100mb.
I have run testing on my end and it works.
![image](https://user-images.githubusercontent.com/61665012/215290758-47cb8cdc-b241-4420-bb73-e16f86678dd3.png)
