### PR TITLE
Added a start script for linux

### DIFF
--- a/start-linux.sh
+++ b/start-linux.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
-if ! [ -x "$(command -v node)" ] || ! [ -x "$(command -v npm)" ]; then
-  echo 'Node.js or npm is not installed. Installing...'
-  
-  TEMP_DIR=$(mktemp -d)
-
-  NODEJS_LATEST=$(curl -s https://nodejs.org/dist/latest/ | grep -Eo 'href=".*linux-x64.tar.xz"' | cut -d'"' -f2)
-  curl -o "$TEMP_DIR/nodejs.tar.xz" "https://nodejs.org/dist/latest/$NODEJS_LATEST"
-
-  sudo mkdir -p /usr/local/lib/nodejs
-  sudo tar -xJvf "$TEMP_DIR/nodejs.tar.xz" -C /usr/local/lib/nodejs
-  NODE_VERSION=$(ls /usr/local/lib/nodejs | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+")
-  echo "export PATH=/usr/local/lib/nodejs/$NODE_VERSION/bin:\$PATH" >> ~/.profile
-  . ~/.profile
-
-  rm -rf "$TEMP_DIR"
+# Check if Node.js and npm are installed
+if ! command -v node &> /dev/null; then
+    echo "Node.js is not installed."
+    read -p "Do you want to install Node.js? [y/n]: " answer
+    if [ "$answer" == "y" ]; then
+        # Download and install Node.js
+        echo "Downloading and installing Node.js..."
+        tempdir=$(mktemp -d)
+        curl -s https://nodejs.org/dist/latest/ | grep -o 'node-v.*-linux-x64.tar.xz' | head -1 | xargs -I {} curl -sLO https://nodejs.org/dist/latest/{}
+        sudo mkdir -p /usr/local/lib/nodejs
+        sudo tar -xJvf node-*-linux-x64.tar.xz -C /usr/local/lib/nodejs --strip-components=1
+        version=$(ls /usr/local/lib/nodejs | grep -o 'node-v.*-linux-x64' | sed 's/node-v//')
+        echo "export PATH=/usr/local/lib/nodejs/node-$version-linux-x64/bin:\$PATH" >> ~/.profile
+        . ~/.profile
+        rm -rf "$tempdir"
+    fi
 fi
 
+# Run npm install
 npm i
+
+# Start the server
 node server.js

--- a/start-linux.sh
+++ b/start-linux.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if ! [ -x "$(command -v node)" ] || ! [ -x "$(command -v npm)" ]; then
+  echo 'Node.js or npm is not installed. Installing...'
+  
+  TEMP_DIR=$(mktemp -d)
+
+  NODEJS_LATEST=$(curl -s https://nodejs.org/dist/latest/ | grep -Eo 'href=".*linux-x64.tar.xz"' | cut -d'"' -f2)
+  curl -o "$TEMP_DIR/nodejs.tar.xz" "https://nodejs.org/dist/latest/$NODEJS_LATEST"
+
+  sudo mkdir -p /usr/local/lib/nodejs
+  sudo tar -xJvf "$TEMP_DIR/nodejs.tar.xz" -C /usr/local/lib/nodejs
+  NODE_VERSION=$(ls /usr/local/lib/nodejs | grep -oE "v[0-9]+\.[0-9]+\.[0-9]+")
+  echo "export PATH=/usr/local/lib/nodejs/$NODE_VERSION/bin:\$PATH" >> ~/.profile
+  . ~/.profile
+
+  rm -rf "$TEMP_DIR"
+fi
+
+npm i
+node server.js


### PR DESCRIPTION
The script performs these functions:

- Checks for `node` and `npm`, installs the latest version from the official binaries.
- Launches `server.js`.

I propose having a separate installer script that would run `npm i` for both Windows and Linux. The start script could just be `node server.js`.