### PR TITLE
EXIF specification compatibility for alternative parsers/writers

### DIFF
--- a/server.js
+++ b/server.js
@@ -748,6 +748,9 @@ async function charaRead(img_url, input_format){
         case 'webp':
             const exif_data = await ExifReader.load(fs.readFileSync(img_url));
             const char_data = exif_data['UserComment']['description'];
+            if (char_data === 'Undefined' && exif_data['UserComment'].value && exif_data['UserComment'].value.length === 1) {
+                return exif_data['UserComment'].value[0];
+            }
             return char_data;
         case 'png':
             const buffer = fs.readFileSync(img_url);


### PR DESCRIPTION
Tavern's implementation of writing to the EXIF metadata of WebP files writes to the UserComment tag inside of IFD0 as a string, making the reader return the character json in the "description" of the UserComment tag. 

Multiple reader/writer/parser implementations for EXIF data do not read/write to UserComment in this way (example: Python PIL/pillow), instead writing the UserComment tag inside of SubIFD with an undefined format. 

This change would allow WebP files created using this specification to be read properly also.

Webpages with the specification I'm referring to:
- https://exiftool.org/TagNames/EXIF.html
- https://www.media.mit.edu/pia/Research/deepview/exif.html