### PR TITLE
Explicit address binding

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -10,7 +10,7 @@ const characterFormat = 'png'; // webp or png
 
 const charaCloudServer = 'https://tavernai.net'; //'https://tavernai.net'; http://127.0.0.1
 
-const listenIp = '127.0.0.1'; // The IP address to which the socket is bound. This is an advanced setting; do not modify the setting unless you have knowledge of networking.
+const listenIp = null; // The IP address to which the socket is bound, set automatically if left as null. This is an advanced setting; do not modify the setting unless you have knowledge of networking.
 
 const connectionTimeoutMS = 2*60*1000; // (2 mintues, change the first number if you have a really slow local API.) The maximum duration of the request, after which TAI assumes the server will not reply at all (default is 2 minutes)
 

--- a/server.js
+++ b/server.js
@@ -46,15 +46,8 @@ if (config.listenIp) {
     // If an advanced user has set the listen IP we use it explicitly
     listenIp = config.listenIp;    
 } else if (!whitelistMode || whitelist.length > 1) {
-    // If whitelist mode is disabled or there are multiple IPs in the whitelist
+    // If whitelist mode is disabled OR there are multiple IPs in the whitelist
     // we listen on all interfaces.
-
-    // This logic is a bit weird, if white list mode is disabled, why would
-    // you want to make your server available on all interfaces by default? 
-    // I suppose if you specify multiple IPs in the whitelist, it's probably 
-    // because you have multiple interfaces and you want to make the server 
-    // available only on those interfaces? This sounds like an advanced use case
-    // to me, but I'm keeping the logic as it was in the original code for now.
     listenIp = '0.0.0.0';
 } else {
     // Otherwise we listen on the loopback address only

--- a/server.js
+++ b/server.js
@@ -2698,7 +2698,6 @@ module.exports.charactersPath = charactersPath;
 
 const charaCloudRoute = require('./routes/characloud');
 const e = require('express');
-const { listen } = require('express/lib/application');
 
 app.use('/api/characloud', charaCloudRoute);
 


### PR DESCRIPTION
# Description
The white list setup logic sometimes overrides whatever is set for the address binding.

Resolves TavernAI/TavernAI#247

# Implication
Making assumptions for the address binding makes some sense for non-advanced users.

For advanced users their settings are not honoured.

# Remediation

If address binding has explicitly been configured, honour it. Only apply binding assumptions if the address binding has not been configured.

# Changes
* The default `listenIp` in `config.conf` is `null` to indicate that white list logic address binding is to be activated
* White list logic address binding honours the address if it is explicitly configured
* Warning if the binding is not a `loopback` address and white list mode is disabled