### PR TITLE
Ollama integration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -331,6 +331,22 @@
                     </div>
                     
                 </div>
+                <div id="master_settings_ollama_block" class="master_settings_range_block" style="display: none;">
+                    <div>
+                        <h4 class="range_title">Top P Sampling </h4><h5 id="top_p_counter_ollama" class="range_counter">1.0</h5>
+                        <input type="range" class="range_bar" id="top_p_ollama" name="volume" min="0.0" max="1.0" step="0.01" value="1.0">
+                    </div>
+                    <div>
+                        <h4 class="range_title">Top K Sampling </h4><h5 id="top_k_counter_ollama" class="range_counter">0</h5>
+                        <input type="range" class="range_bar" id="top_k_ollama" name="volume" min="0" max="100" step="1" value="0">
+                    </div>
+                    <div>
+                        <h4 class="range_title">Context Size</h4><h5 id="max_context_counter_ollama" style="display: inline-block" class="range_counter">4096 Tokens</h5>
+                        <div id="ollama_set_context_size_button"><a>(set)</a></div>
+                        <input type="range" class="range_bar" id="max_context_ollama" name="volume" min="512" max="8192" step="128" value="4096">
+                    </div>
+                    <!-- Add other Ollama-specific advanced parameters here if needed -->
+                </div>
                 <div id="system_prompt_block">
                     <div id="system_prompt">
                         <div style="display:grid;grid-template-columns: auto auto;position:relative;width:94%">
@@ -638,6 +654,7 @@
                 <option value="claude">ClaudeAI</option>
                 <option value="proxy">Reverse Proxy</option>
                 <option value="webui">Text generation web UI</option>
+                <option value="ollama">Ollama</option>
             </select>
             <div id="kobold_api">
                 <div id="kobold_api_logo"><a href="https://github.com/henk717/KoboldAI" target="_blank"><img src="img/kobold.png"></a></div>
@@ -827,6 +844,28 @@
                     <input type="range" id="amount_gen" name="volume" min="16" max="512" step="1">-->
                     <h4 class="h4_menu_title">Repetition Penalty </h4><h5 id="rep_pen_counter_webui" class="range_counter">select</h5>
                     <input type="range" id="rep_pen_webui" name="volume" min="1" max="1.5" step="0.01">
+                </div>
+            </div>
+            <div id="ollama_api" style="display: none;">
+                <!-- <div id="ollama_api_logo"><a href="https://ollama.ai/" target="_blank"><img src="img/ollama.png"></a></div> -->
+                <form action="javascript:void(null);" method="post" enctype="multipart/form-data">
+                    <h4 class="h4_menu_title">API URL</h4><h5 class="h5_menu_help">Example: http://127.0.0.1:11434</h5>
+                    <input id="api_url_ollama" name="api_url_ollama" class="text_pole" type="text" maxlength="500" size="35" value="http://127.0.0.1:11434" autocomplete="off">
+                    <input id="api_button_ollama" type="submit" value="Connect">
+                    <img id="api_loading_ollama" src="img/load.svg" style="display: none;">
+                </form>
+                <div id="online_status_ollama">
+                    <div id="online_status_indicator_ollama" class="online_status_indicator_offline"></div><div id="online_status_text_ollama">No connection...</div>
+                </div>
+                <h4 class="h4_menu_title">Model</h4><h5 class="h5_menu_help">Select Ollama model (auto-populated)</h5>
+                <select id="ollama_model_select" class="menu_select">
+                    <option value="">-- Connect to get models --</option>
+                </select>
+                <div id="range_block_ollama">
+                    <h4 class="h4_menu_title">Temperature </h4><h5 id="temp_counter_ollama" class="range_counter">0.7</h5>
+                    <input type="range" id="temp_ollama" name="volume" min="0.0" max="2.0" step="0.01" value="0.7">
+                    <h4 class="h4_menu_title">Amount of generation </h4><h5 id="amount_gen_counter_ollama" class="range_counter">200 Tokens</h5>
+                    <input type="range" id="amount_gen_ollama" name="volume" min="16" max="2048" step="16" value="200">
                 </div>
             </div>
             <div id="additional_menu_settings">

--- a/server.js
+++ b/server.js
@@ -2093,10 +2093,13 @@ app.post("/generate_ollama", jsonParser, function(request, response_generate_oll
 //***********Ollama API
 app.post("/getstatus_ollama", jsonParser, function(request, response_getstatus_ollama_func = response){ // Assign to a different name to avoid conflict
     if(!request.body) return response_getstatus_ollama_func.sendStatus(400);
-    // In a real scenario, you would get the Ollama API URL from the request or config
-    // For now, we use the globally defined api_ollama
 
-    client.get(api_ollama + "/api/tags", function (data, response) { // Ollama uses /api/tags to list models
+    let current_api_ollama = api_ollama; // Default to constant
+    if (request.body.api_url && request.body.api_url.trim() !== '') {
+        current_api_ollama = request.body.api_url.trim();
+    }
+
+    client.get(current_api_ollama + "/api/tags", function (data, response) { // Ollama uses /api/tags to list models
         if(response.statusCode == 200){
             // Assuming data contains model information, similar to other /getstatus endpoints
             // Modify this part based on the actual response structure of Ollama's /api/tags

--- a/server.js
+++ b/server.js
@@ -72,6 +72,7 @@ var api_server = "http://127.0.0.1:5000/api";//"http://127.0.0.1:5000";
 const api_novelai = "https://api.novelai.net";
 const api_openai = "https://api.openai.com/v1";
 const api_horde = "https://stablehorde.net/api";
+const api_ollama = "http://127.0.0.1:11434"; // Default Ollama API URL
 var hordeActive = false;
 var hordeQueue;
 var hordeData = {};
@@ -94,11 +95,13 @@ var response_getstatus;
 var response_getstatus_novel;
 var response_getstatus_openai;
 var response_getstatus_claude;
+var response_getstatus_ollama;
 var response_getlastversion;
 var api_key_novel;
 var api_key_openai;
 var api_key_claude;
 var api_url_openai;
+var model_ollama; // Variable to store Ollama model name
 var is_colab = false;
 var charactersPath = 'public/characters/';
 var worldPath = 'public/worlds/';
@@ -2013,6 +2016,99 @@ app.post("/generate_openai", jsonParser, function(request, response_generate_ope
         response_generate_openai.send({error: true, error_message: "Unspecified error while sending the request.\n" + err});
     });
 });
+
+app.post("/generate_ollama", jsonParser, function(request, response_generate_ollama_func = response){ // Assign to a different name to avoid conflict
+    if(!request.body) return response_generate_ollama_func.sendStatus(400);
+    console.log(request.body);
+
+    // model_ollama should be set by /getstatus_ollama or a settings panel in a real app
+    // For now, ensure it's passed in the request or use a default.
+    const current_model_ollama = request.body.model || model_ollama || "llama2"; // Fallback to llama2 if no model specified
+
+    var data = {
+        "model": current_model_ollama,
+        "prompt": request.body.prompt,
+        "stream": false, // Ollama supports streaming, but for simplicity, we'll use non-streaming for now
+        // Add other parameters as supported by Ollama and needed by TavernAI
+        // e.g., "max_tokens": request.body.max_tokens, "temperature": request.body.temperature etc.
+        // Refer to Ollama documentation for available parameters: https://github.com/jmorganca/ollama/blob/main/docs/api.md
+        "options": {
+            "temperature": request.body.temperature,
+            "top_p": request.body.top_p,
+            "top_k": request.body.top_k,
+            "num_predict": request.body.max_tokens // Ollama uses num_predict for max tokens
+        }
+    };
+
+    var args = {
+        data: data,
+        headers: { "Content-Type": "application/json" },
+        requestConfig: {
+            timeout: connectionTimeoutMS // Use existing timeout setting
+        }
+    };
+
+    client.post(api_ollama + "/api/generate", args, function (data, response) {
+        try {
+            console.log(data); // Log the raw response from Ollama
+            if(response.statusCode == 200){
+                // The response structure for non-streaming is a single JSON object per line.
+                // We need to parse it if it's a string, or use directly if already an object.
+                let ollamaResponse;
+                if (typeof data === 'string') {
+                    // Split by newline and parse the last valid JSON object
+                    // This handles cases where multiple JSON objects might be sent in a single buffer
+                    // or if there are any leading/trailing non-JSON characters (though less likely for non-streaming)
+                    const lines = data.trim().split('\n');
+                    ollamaResponse = JSON.parse(lines[lines.length - 1]);
+                } else {
+                    ollamaResponse = data;
+                }
+                // Adapt the response to the format expected by TavernAI frontend
+                // This usually involves extracting the generated text and any other relevant info.
+                // For Ollama, the generated text is in the "response" field.
+                response_generate_ollama_func.send({ choices: [{ text: ollamaResponse.response }], usage: {completion_tokens: ollamaResponse.eval_count, prompt_tokens: ollamaResponse.prompt_eval_count} });
+            } else {
+                console.log("Ollama API Error - Status Code:", response.statusCode);
+                console.log("Ollama API Error - Data:", data);
+                let errorMessage = "Error generating text with Ollama.";
+                if (data && data.error) {
+                    errorMessage = data.error;
+                } else if (typeof data === 'string') {
+                    errorMessage = data;
+                }
+                response_generate_ollama_func.send({error: true, error_message: errorMessage, error_code: response.statusCode});
+            }
+        } catch (error) {
+            console.log("Error processing Ollama response: " + error);
+            console.log("Raw data from Ollama:", data); // Log raw data on error
+            response_generate_ollama_func.send({error: true, error_message: "Error processing Ollama response: " + error.message});
+        }
+    }).on('error', function (err) {
+        console.log("Ollama request error:", err);
+        response_generate_ollama_func.send({error: true, error_message: "Unspecified error while sending the request to Ollama.\n" + err});
+    });
+});
+
+//***********Ollama API
+app.post("/getstatus_ollama", jsonParser, function(request, response_getstatus_ollama_func = response){ // Assign to a different name to avoid conflict
+    if(!request.body) return response_getstatus_ollama_func.sendStatus(400);
+    // In a real scenario, you would get the Ollama API URL from the request or config
+    // For now, we use the globally defined api_ollama
+
+    client.get(api_ollama + "/api/tags", function (data, response) { // Ollama uses /api/tags to list models
+        if(response.statusCode == 200){
+            // Assuming data contains model information, similar to other /getstatus endpoints
+            // Modify this part based on the actual response structure of Ollama's /api/tags
+            response_getstatus_ollama_func.send(data);
+        } else {
+            response_getstatus_ollama_func.send({error: true, error_message: "Error connecting to Ollama. Status code: " + response.statusCode});
+        }
+    }).on('error', function (err) {
+        response_getstatus_ollama_func.send({error: true, error_message: "Unspecified error while sending the request to Ollama.\n" + err});
+    });
+});
+
 function isChatModel(model_openai){
     if (model_openai === 'text-davinci-003' || model_openai === 'text-davinci-002' || model_openai === 'text-curie-001' || model_openai === 'text-babbage-001' || model_openai === 'text-ada-001' || model_openai === 'code-davinci-002' || model_openai === 'gpt-3.5-turbo-instruct') {
         return false;


### PR DESCRIPTION
Please let me know if I missed something or if there was a technical reason for not having this before.  
 
 **Backend:**
- Added two new endpoints in server.js: /getstatus_ollama and /generate_ollama.
- API URL for Ollama is now configurable, so it works whether you're connecting directly or using a reverse proxy.
- Improved how paths like /api/tags and /api/generate are built — trailing slashes or not, it just works.

**Frontend:**
Updated public/script.js to:
- Handle new Ollama settings like api_url_ollama and model_ollama.
- Talk to the new backend endpoints.
- Populate the Ollama model dropdown from the API response.
- Remember and reload your Ollama settings.

**UI Updates:**
Tweaked public/index.html to:
- Add Ollama as an option in the API selector.
- Show a new settings section for Ollama in the Master Settings popup.
- Include controls like a Top P slider for customizing generation.